### PR TITLE
Update links, restructure, add link checker workflow

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,28 @@
+name: check links
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  checklinks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Restore lychee cache
+        uses: actions/cache@v3
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: "--cache --max-cache-age 1d ."
+          fail: true

--- a/profile/README.md
+++ b/profile/README.md
@@ -2,44 +2,40 @@
 
 ## Welcome to Confidential Containers
 
-Confidential Containers is an open source community working to enable cloud native confidential 
-computing by leveraging 
-[Trusted Execution Environments](https://en.wikipedia.org/wiki/Trusted_execution_environment) to 
+Confidential Containers is an open source community working to enable cloud native confidential
+computing by leveraging
+[Trusted Execution Environments](https://en.wikipedia.org/wiki/Trusted_execution_environment) to
 protect containers and data.
-
-**We have a new release every 6 weeks!**
-See [Release Notes](https://github.com/confidential-containers/confidential-containers/tree/main/releases)
-or [Quickstart Guide](https://github.com/confidential-containers/confidential-containers/blob/main/quickstart.md)
 
 Goals:
 - Allow cloud native application owners to enforce application security requirements
 - Transparent deployment of unmodified containers
 - Support for multiple TEE and hardware platforms
 - A trust model which separates Cloud Service Providers (CSPs) from guest applications
-- Least privilege principles for the Kubernetes Cluster administration capabilities which impact 
+- Least privilege principles for the Kubernetes Cluster administration capabilities which impact
 delivering Confidential Computing for guest application or data inside the TEE.
 
 ### Find out more
-- [**Documentation**](https://github.com/confidential-containers/confidential-containers) Learn about our 
+
+- [**Documentation**](https://github.com/confidential-containers/confidential-containers) Learn about our
 vision, goals, and progress.
+- [**Latest release notes**](https://github.com/confidential-containers/confidential-containers/tree/main/releases) We have a new release every 6 weeks!
 
 ### Get started
+
+- [**Quickstart Guide**](https://github.com/confidential-containers/confidential-containers/blob/main/quickstart.md)
 - [**Kubernetes Operator**](https://github.com/confidential-containers/operator)
 Deploy Confidential Containers on a Kubernetes cluster with an operator.
 
 ### Join the community
+
 - [**Weekly Meetings**](https://docs.google.com/document/d/1E3GLCzNgrcigUlgWAZYlgqNTdVwiMwCRTJ0QnJhLZGA/)
 Check out our previous meetings and join our future ones.
 - [**Slack Discussion**](https://slack.cncf.io ) Join the `#confidential-containers` channel.
-
-### Confidential Containers Code of Conduct
-Confidential Containers follows the
-[CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+- [**Community guidelines**](https://github.com/confidential-containers/confidential-containers) How to contribute, style guides, governance...
+- [**Code of Conduct**](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) We follow the CNCF Code of Conduct.
 
 ---
 ![cncf-logo](https://github.com/confidential-containers/.github/blob/main/cncf-logo.png)
 
 Confidential Containers is a Cloud Native Computing Foundation sandbox project.
-
-*For community guidelines and policies, please see the [community repository](https://github.com/confidential-containers/confidential-containers).*
-

--- a/profile/README.md
+++ b/profile/README.md
@@ -8,8 +8,8 @@ computing by leveraging
 protect containers and data.
 
 **We have a new release every 6 weeks!**
-See [Release Notes](https://github.com/confidential-containers/documentation/tree/main/releases)
-or [Quickstart Guide](https://github.com/confidential-containers/documentation/blob/main/quickstart.md)
+See [Release Notes](https://github.com/confidential-containers/confidential-containers/tree/main/releases)
+or [Quickstart Guide](https://github.com/confidential-containers/confidential-containers/blob/main/quickstart.md)
 
 Goals:
 - Allow cloud native application owners to enforce application security requirements
@@ -20,11 +20,11 @@ Goals:
 delivering Confidential Computing for guest application or data inside the TEE.
 
 ### Find out more
-- [**Documentation**](https://github.com/confidential-containers/documentation) Learn about our 
+- [**Documentation**](https://github.com/confidential-containers/confidential-containers) Learn about our 
 vision, goals, and progress.
 
 ### Get started
-- [**Kubernetes Operator**](https://github.com/confidential-containers/confidential-containers-operator)
+- [**Kubernetes Operator**](https://github.com/confidential-containers/operator)
 Deploy Confidential Containers on a Kubernetes cluster with an operator.
 
 ### Join the community
@@ -41,5 +41,5 @@ Confidential Containers follows the
 
 Confidential Containers is a Cloud Native Computing Foundation sandbox project.
 
-*For community guidelines and policies, please see the [community repository](https://github.com/confidential-containers/community).*
+*For community guidelines and policies, please see the [community repository](https://github.com/confidential-containers/confidential-containers).*
 


### PR DESCRIPTION
As community and docs are now merged together, it isn't that simple anymore to link to one or another. Maybe we could give the new repo some more structure or create overview pages for specific topics.