### PR TITLE
security: clarify security roles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,10 @@ and you should go to their upstream, rather than filing an issuing on our fork.)
 If you're creating an issue that you plan to resolve, consider noting this in
 a comment so other developers know that someone is working on the problem.
 
+#### Security
+
+If your issue is related to security, see the [security policy](SECURITY.md).
+
 ## Making Contributions
 
 The mechanics of making a contribution are straightforward.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ Please do not use public issues to report security vulnerabilities.
 To report a vulnerability please select the security tab of the repo and
 click `Report a vulnerability`. 
 This will create a private github issue that CoCo maintainers
-and security champions will be able to see.
+and security managers will be able to see.
 
 The CoCo community aspires to follow the security best practices defined by OpenSSF,
 including responding to vulnerability reports within 14 days.
@@ -31,3 +31,9 @@ CoCo announces security issues and their fixes in the release notes of the patch
 For example, a vulnerability discovered in v0.8 and fixed in v0.8.1 will be announced in the
 release notes for v0.8.1.
 
+# Security Managers
+
+Confidential Containers security managers, along with the Steering Committee, and the maintainers
+of individual repos are expected to engage with security issues.
+More information about these roles is available in the Confidential Containers
+[governance document](https://github.com/confidential-containers/confidential-containers/blob/main/governance.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,12 +6,23 @@ Please do not use public issues to report security vulnerabilities.
 
 To report a vulnerability please select the security tab of the repo and
 click `Report a vulnerability`. 
-This will create a private github issue that CoCo maintainers
-and security managers will be able to see.
+This will create a private GitHub issue that repository maintainers,
+security managers, and the steering committee will have access to.
+
+Private GitHub issues provide a structured protocol for addressing security concerns.
+The aforementioned parties will use this mechanism to triage the issue in collaboration
+with the author of the issue.
+If the issue is accepted as a CVE, security managers will make sure that the author
+has provided correct information and that an accurate severity score is calculated.
+A CVE number will be issued via GitHub.
+A private branch may be used to resolve the issue.
+Once the issue is fixed, the CVE should be published.
+The security managers should share the CVE with the broader community at this point.
+Prior to publication, the vulnerability is considered embargoed and information
+about it should be shared on a need-to-know basis.
 
 The CoCo community aspires to follow the security best practices defined by OpenSSF,
 including responding to vulnerability reports within 14 days.
-
 
 ## Supported Versions
 


### PR DESCRIPTION
Reference our governance doc regarding the roles. Also, ditch the "security champions" name in favor of "security managers."

Also, add a link to the security doc to the contributing guide.